### PR TITLE
Improve suggestion application and add scene change helper

### DIFF
--- a/client/src/components/PromptEnhancementEditor.jsx
+++ b/client/src/components/PromptEnhancementEditor.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { Loader2, Sparkles, X, Info } from 'lucide-react';
+import { detectAndApplySceneChange } from '../utils/detectSceneChange';
 
 export default function PromptEnhancementEditor({
   promptContent,
@@ -136,122 +137,15 @@ export default function PromptEnhancementEditor({
   const handleSuggestionClick = async (suggestionText) => {
     const updatedPrompt = promptContent.replace(selectedText, suggestionText);
 
-    // Check if this is an environment change in a WHERE section
-    await detectAndHandleSceneChange(
-      selectedText,
-      suggestionText,
-      updatedPrompt
-    );
+    const finalPrompt = await detectAndApplySceneChange({
+      originalPrompt: promptContent,
+      updatedPrompt,
+      oldValue: selectedText,
+      newValue: suggestionText,
+    });
 
-    onPromptUpdate(updatedPrompt);
+    onPromptUpdate(finalPrompt);
     handleClose();
-  };
-
-  // Detect if changing Environment Type and offer to update related fields
-  const detectAndHandleSceneChange = async (
-    oldValue,
-    newValue,
-    updatedPrompt
-  ) => {
-    // Check if we're in the WHERE section and changing Environment Type
-    const whereMatch = promptContent.match(
-      /\*\*WHERE - LOCATION\/SETTING\*\*[\s\S]*?(?=\*\*WHEN|$)/
-    );
-    if (!whereMatch) return;
-
-    const whereSection = whereMatch[0];
-    const envTypeMatch = whereSection.match(/- Environment Type: \[(.*?)\]/);
-
-    // Check if the selected text is the Environment Type value
-    if (!envTypeMatch || !whereSection.includes(selectedText)) return;
-
-    const isEnvironmentType =
-      whereSection.indexOf(selectedText) >
-        whereSection.indexOf('- Environment Type:') &&
-      whereSection.indexOf(selectedText) <
-        whereSection.indexOf('- Architectural Details:');
-
-    if (!isEnvironmentType) return;
-
-    // Define the related fields that might need updating
-    const affectedFieldsMap = {
-      'Architectural Details':
-        whereSection.match(/- Architectural Details: \[(.*?)\]/)?.[1] || '',
-      'Environmental Scale':
-        whereSection.match(/- Environmental Scale: \[(.*?)\]/)?.[1] || '',
-      'Atmospheric Conditions':
-        whereSection.match(/- Atmospheric Conditions: \[(.*?)\]/)?.[1] || '',
-      'Background Elements':
-        whereSection.match(/- Background Elements: \[(.*?)\]/)?.[1] || '',
-      'Foreground Elements':
-        whereSection.match(/- Foreground Elements: \[(.*?)\]/)?.[1] || '',
-      'Spatial Depth':
-        whereSection.match(/- Spatial Depth: \[(.*?)\]/)?.[1] || '',
-      'Environmental Storytelling':
-        whereSection.match(/- Environmental Storytelling: \[(.*?)\]/)?.[1] ||
-        '',
-    };
-
-    try {
-      const response = await fetch(
-        '/api/detect-scene-change',
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-API-Key': 'dev-key-12345'
-          },
-          body: JSON.stringify({
-            changedField: 'Environment Type',
-            oldValue,
-            newValue,
-            fullPrompt: updatedPrompt,
-            affectedFields: affectedFieldsMap,
-          }),
-        }
-      );
-
-      if (!response.ok) return;
-
-      const result = await response.json();
-
-      if (result.isSceneChange && result.confidence !== 'low') {
-        // Show confirmation dialog
-        const shouldUpdate = window.confirm(
-          `🎬 Scene Change Detected!\n\n` +
-            `Changing from "${oldValue}" to "${newValue}" represents a complete environment change.\n\n` +
-            `Would you like to automatically update the related location fields to match this new environment?\n\n` +
-            `${result.reasoning}`
-        );
-
-        if (shouldUpdate && result.suggestedUpdates) {
-          // Apply the suggested updates
-          let finalPrompt = updatedPrompt;
-
-          Object.entries(result.suggestedUpdates).forEach(
-            ([fieldName, newFieldValue]) => {
-              const oldFieldValue = affectedFieldsMap[fieldName];
-              if (oldFieldValue && newFieldValue) {
-                // Replace the old value with the new value for this field
-                const fieldPattern = new RegExp(
-                  `(- ${fieldName}: \\[)${oldFieldValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\])`,
-                  'g'
-                );
-                finalPrompt = finalPrompt.replace(
-                  fieldPattern,
-                  `$1${newFieldValue}$2`
-                );
-              }
-            }
-          );
-
-          onPromptUpdate(finalPrompt);
-        }
-      }
-    } catch (error) {
-      console.error('Error detecting scene change:', error);
-      // Silently fail - don't disrupt the user's workflow
-    }
   };
 
   // Close suggestions panel

--- a/client/src/features/prompt-optimizer/PromptOptimizerContainer.jsx
+++ b/client/src/features/prompt-optimizer/PromptOptimizerContainer.jsx
@@ -27,6 +27,7 @@ import KeyboardShortcuts, { useKeyboardShortcuts } from '../../components/Keyboa
 import { usePromptOptimizer } from '../../hooks/usePromptOptimizer';
 import { usePromptHistory } from '../../hooks/usePromptHistory';
 import { PromptContext } from '../../utils/PromptContext';
+import { detectAndApplySceneChange } from '../../utils/detectSceneChange';
 
 function PromptOptimizerContent() {
   // Force light mode immediately
@@ -279,7 +280,8 @@ function PromptOptimizerContent() {
     highlightedText,
     originalText,
     fullPrompt,
-    selectionRange
+    selectionRange,
+    selectionOffsets
   ) => {
     // Only enable ML suggestions for video mode
     if (selectedMode !== 'video') {
@@ -302,6 +304,136 @@ function PromptOptimizerContent() {
       const requestId = Symbol('suggestions');
       lastRequestRef.current = requestId;
 
+      const rangeSnapshot = selectionRange ? selectionRange.cloneRange() : null;
+      const hasValidOffsets =
+        selectionOffsets &&
+        typeof selectionOffsets.start === 'number' &&
+        typeof selectionOffsets.end === 'number';
+      const offsetsSnapshot = hasValidOffsets
+        ? {
+            start: selectionOffsets.start,
+            end: selectionOffsets.end,
+          }
+        : null;
+      const exactSelectionText =
+        offsetsSnapshot && fullPrompt
+          ? fullPrompt.slice(offsetsSnapshot.start, offsetsSnapshot.end)
+          : originalText;
+
+      const closeSuggestions = () => {
+        setSuggestionsData(null);
+        if (typeof window !== 'undefined' && window.getSelection) {
+          const selection = window.getSelection();
+          if (selection && selection.removeAllRanges) {
+            selection.removeAllRanges();
+          }
+        }
+      };
+
+      const applySuggestion = async (suggestionText) => {
+        try {
+          const latestPrompt = promptOptimizer.displayedPrompt;
+
+          if (!latestPrompt) {
+            toast.error('Unable to apply suggestion to an empty prompt');
+            return;
+          }
+
+          if (rangeSnapshot && typeof window !== 'undefined' && window.getSelection) {
+            try {
+              const selection = window.getSelection();
+              if (selection && selection.removeAllRanges && selection.addRange) {
+                selection.removeAllRanges();
+                const rangeToApply = rangeSnapshot.cloneRange
+                  ? rangeSnapshot.cloneRange()
+                  : rangeSnapshot;
+                selection.addRange(rangeToApply);
+              }
+            } catch (rangeError) {
+              console.warn('Unable to restore previous selection range:', rangeError);
+            }
+          }
+
+          let startIndex = offsetsSnapshot?.start ?? -1;
+          let endIndex = offsetsSnapshot?.end ?? -1;
+          let replacementSource = exactSelectionText || highlightedText || originalText || '';
+          let currentSlice =
+            startIndex >= 0 && endIndex >= 0
+              ? latestPrompt.slice(startIndex, endIndex)
+              : '';
+
+          const hasValidSlice =
+            startIndex >= 0 &&
+            endIndex >= 0 &&
+            startIndex <= endIndex &&
+            currentSlice &&
+            latestPrompt.length >= endIndex;
+
+          if (!hasValidSlice || currentSlice !== replacementSource) {
+            const fallbackText = replacementSource;
+            if (fallbackText) {
+              const fallbackStart = latestPrompt.indexOf(fallbackText);
+              if (fallbackStart !== -1) {
+                startIndex = fallbackStart;
+                endIndex = fallbackStart + fallbackText.length;
+                currentSlice = latestPrompt.slice(startIndex, endIndex);
+              }
+            }
+          }
+
+          let updatedPrompt = latestPrompt;
+          const finalStartValid =
+            startIndex >= 0 &&
+            endIndex >= 0 &&
+            startIndex <= endIndex &&
+            latestPrompt.length >= endIndex;
+
+          const replacedText =
+            finalStartValid && currentSlice
+              ? currentSlice
+              : replacementSource;
+
+          if (finalStartValid && currentSlice) {
+            updatedPrompt =
+              latestPrompt.slice(0, startIndex) +
+              suggestionText +
+              latestPrompt.slice(endIndex);
+          } else if (replacementSource) {
+            updatedPrompt = latestPrompt.replace(replacementSource, suggestionText);
+          }
+
+          try {
+            const finalPrompt = await detectAndApplySceneChange({
+              originalPrompt: latestPrompt,
+              updatedPrompt,
+              oldValue: replacedText || replacementSource,
+              newValue: suggestionText,
+            });
+
+            promptOptimizer.setOptimizedPrompt(finalPrompt);
+            promptOptimizer.setDisplayedPrompt(finalPrompt);
+            closeSuggestions();
+            toast.success('Suggestion applied');
+          } catch (error) {
+            console.error('Error detecting scene change:', error);
+            promptOptimizer.setOptimizedPrompt(updatedPrompt);
+            promptOptimizer.setDisplayedPrompt(updatedPrompt);
+            closeSuggestions();
+            toast.success('Suggestion applied');
+          }
+        } catch (error) {
+          console.error('Error applying suggestion:', error);
+          toast.error('Failed to apply suggestion');
+        } finally {
+          if (typeof window !== 'undefined' && window.getSelection) {
+            const selection = window.getSelection();
+            if (selection && selection.removeAllRanges) {
+              selection.removeAllRanges();
+            }
+          }
+        }
+      };
+
       const highlightIndex = fullPrompt.indexOf(highlightedText);
       const contextBefore = fullPrompt
         .substring(Math.max(0, highlightIndex - 300), highlightIndex)
@@ -320,37 +452,29 @@ function PromptOptimizerContent() {
       setSuggestionsData({
         show: true,
         selectedText: highlightedText,
-        originalText: originalText,
+        originalText: exactSelectionText,
         suggestions: [],
         isLoading: true,
         isPlaceholder: false,
         fullPrompt: fullPrompt,
+        selectionRange: rangeSnapshot,
+        selectionOffsets: offsetsSnapshot,
         setSuggestions: (newSuggestions, newIsPlaceholder) => {
-          setSuggestionsData((prev) => ({
-            ...prev,
-            suggestions: newSuggestions,
-            isPlaceholder:
-              newIsPlaceholder !== undefined
-                ? newIsPlaceholder
-                : prev.isPlaceholder,
-            isLoading: false,
-          }));
+          setSuggestionsData((prev) => {
+            if (!prev) return prev;
+            return {
+              ...prev,
+              suggestions: newSuggestions,
+              isPlaceholder:
+                newIsPlaceholder !== undefined
+                  ? newIsPlaceholder
+                  : prev.isPlaceholder,
+              isLoading: false,
+            };
+          });
         },
-        onSuggestionClick: (suggestionText) => {
-          const updatedPrompt = promptOptimizer.displayedPrompt.replace(
-            originalText,
-            suggestionText
-          );
-          promptOptimizer.setOptimizedPrompt(updatedPrompt);
-          promptOptimizer.setDisplayedPrompt(updatedPrompt);
-          setSuggestionsData(null);
-          window.getSelection().removeAllRanges();
-          toast.success('Suggestion applied');
-        },
-        onClose: () => {
-          setSuggestionsData(null);
-          window.getSelection().removeAllRanges();
-        },
+        onSuggestionClick: applySuggestion,
+        onClose: closeSuggestions,
       });
 
       try {
@@ -383,47 +507,21 @@ function PromptOptimizerContent() {
           return;
         }
 
-        setSuggestionsData({
-          show: true,
-          selectedText: highlightedText,
-          originalText: originalText,
-          suggestions: data.suggestions || [],
-          isLoading: false,
-          isPlaceholder: data.isPlaceholder || false,
-          fullPrompt: fullPrompt,
-          setSuggestions: (newSuggestions, newIsPlaceholder) => {
-            setSuggestionsData((prev) => ({
-              ...prev,
-              suggestions: newSuggestions,
-              isPlaceholder:
-                newIsPlaceholder !== undefined
-                  ? newIsPlaceholder
-                  : prev.isPlaceholder,
-              isLoading: false,
-            }));
-          },
-          onSuggestionClick: (suggestionText) => {
-            const updatedPrompt = promptOptimizer.displayedPrompt.replace(
-              originalText,
-              suggestionText
-            );
-            promptOptimizer.setOptimizedPrompt(updatedPrompt);
-            promptOptimizer.setDisplayedPrompt(updatedPrompt);
-            setSuggestionsData(null);
-            window.getSelection().removeAllRanges();
-            toast.success('Suggestion applied');
-          },
-          onClose: () => {
-            setSuggestionsData(null);
-            window.getSelection().removeAllRanges();
-          },
+        setSuggestionsData((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            suggestions: data.suggestions || [],
+            isLoading: false,
+            isPlaceholder: data.isPlaceholder || false,
+          };
         });
       } catch (error) {
         console.error('Error fetching suggestions:', error);
         // Only surface the error if this is still the latest request
         if (lastRequestRef.current === requestId) {
           toast.error('Failed to load suggestions');
-          setSuggestionsData(null);
+          closeSuggestions();
         }
       }
     };

--- a/client/src/utils/detectSceneChange.js
+++ b/client/src/utils/detectSceneChange.js
@@ -1,0 +1,152 @@
+const escapeRegExp = (value) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const defaultConfirm = (message) => {
+  if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
+    return window.confirm(message);
+  }
+  return true;
+};
+
+export async function detectAndApplySceneChange({
+  originalPrompt,
+  updatedPrompt,
+  oldValue,
+  newValue,
+  fetchImpl,
+  confirmSceneChange,
+}) {
+  const sourcePrompt = typeof originalPrompt === 'string' ? originalPrompt : '';
+  const baselinePrompt =
+    typeof updatedPrompt === 'string' ? updatedPrompt : sourcePrompt;
+
+  if (!sourcePrompt || !baselinePrompt) {
+    return baselinePrompt || sourcePrompt;
+  }
+
+  if (!oldValue || !newValue || oldValue === newValue) {
+    return baselinePrompt;
+  }
+
+  const whereMatch = sourcePrompt.match(
+    /\*\*WHERE - LOCATION\/SETTING\*\*[\s\S]*?(?=\*\*WHEN|$)/
+  );
+
+  if (!whereMatch) {
+    return baselinePrompt;
+  }
+
+  const whereSection = whereMatch[0];
+  const envLabelIndex = whereSection.indexOf('- Environment Type:');
+  const selectionIndex = whereSection.indexOf(oldValue);
+
+  if (envLabelIndex === -1 || selectionIndex === -1) {
+    return baselinePrompt;
+  }
+
+  const envTypeMatch = whereSection.match(/- Environment Type: \[(.*?)\]/);
+  if (!envTypeMatch) {
+    return baselinePrompt;
+  }
+
+  const nextFieldIndex = whereSection.indexOf('- Architectural Details:');
+  const isEnvironmentType =
+    selectionIndex > envLabelIndex &&
+    (nextFieldIndex === -1 || selectionIndex < nextFieldIndex);
+
+  if (!isEnvironmentType) {
+    return baselinePrompt;
+  }
+
+  const affectedFieldsMap = {
+    'Architectural Details':
+      whereSection.match(/- Architectural Details: \[(.*?)\]/)?.[1] || '',
+    'Environmental Scale':
+      whereSection.match(/- Environmental Scale: \[(.*?)\]/)?.[1] || '',
+    'Atmospheric Conditions':
+      whereSection.match(/- Atmospheric Conditions: \[(.*?)\]/)?.[1] || '',
+    'Background Elements':
+      whereSection.match(/- Background Elements: \[(.*?)\]/)?.[1] || '',
+    'Foreground Elements':
+      whereSection.match(/- Foreground Elements: \[(.*?)\]/)?.[1] || '',
+    'Spatial Depth':
+      whereSection.match(/- Spatial Depth: \[(.*?)\]/)?.[1] || '',
+    'Environmental Storytelling':
+      whereSection.match(/- Environmental Storytelling: \[(.*?)\]/)?.[1] || '',
+  };
+
+  const fetchFn =
+    fetchImpl || (typeof fetch !== 'undefined' ? fetch : undefined);
+
+  if (!fetchFn) {
+    return baselinePrompt;
+  }
+
+  const confirmFn = confirmSceneChange || defaultConfirm;
+
+  try {
+    const response = await fetchFn('/api/detect-scene-change', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': 'dev-key-12345',
+      },
+      body: JSON.stringify({
+        changedField: 'Environment Type',
+        oldValue,
+        newValue,
+        fullPrompt: baselinePrompt,
+        affectedFields: affectedFieldsMap,
+      }),
+    });
+
+    if (!response || !response.ok) {
+      return baselinePrompt;
+    }
+
+    const result = await response.json();
+
+    if (!result || !result.isSceneChange || result.confidence === 'low') {
+      return baselinePrompt;
+    }
+
+    const confirmationMessage =
+      `🎬 Scene Change Detected!\n\n` +
+      `Changing from "${oldValue}" to "${newValue}" represents a complete environment change.\n\n` +
+      `Would you like to automatically update the related location fields to match this new environment?\n\n` +
+      `${result.reasoning || ''}`;
+
+    const shouldUpdate = confirmFn(confirmationMessage);
+
+    if (!shouldUpdate || !result.suggestedUpdates) {
+      return baselinePrompt;
+    }
+
+    let finalPrompt = baselinePrompt;
+
+    Object.entries(result.suggestedUpdates).forEach(([fieldName, newFieldValue]) => {
+      const oldFieldValue = affectedFieldsMap[fieldName];
+
+      if (!oldFieldValue || !newFieldValue) {
+        return;
+      }
+
+      const pattern = new RegExp(
+        `(- ${escapeRegExp(fieldName)}: \\[)${escapeRegExp(oldFieldValue)}(\\])`,
+        'g'
+      );
+
+      finalPrompt = finalPrompt.replace(
+        pattern,
+        `$1${newFieldValue}$2`
+      );
+    });
+
+    return finalPrompt;
+  } catch (error) {
+    console.error('Error detecting scene change:', error);
+    return baselinePrompt;
+  }
+}
+
+export default detectAndApplySceneChange;

--- a/tests/unit/client/utils/detectSceneChange.test.js
+++ b/tests/unit/client/utils/detectSceneChange.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from 'vitest';
+import { detectAndApplySceneChange } from '../../../../client/src/utils/detectSceneChange.js';
+
+describe('detectAndApplySceneChange', () => {
+  const basePrompt = `\n**WHERE - LOCATION/SETTING**\n- Environment Type: [Forest]\n- Architectural Details: [Wooden cabins]\n- Environmental Scale: [Intimate]\n- Atmospheric Conditions: [Misty]\n- Background Elements: [Tall pines]\n- Foreground Elements: [Mossy rocks]\n- Spatial Depth: [Layered]\n- Environmental Storytelling: [Tranquil retreat]\n\n**WHEN - TIME/ERA**\n- Time of Day: [Dawn]\n`;
+
+  it('returns updated prompt when WHERE section is missing', async () => {
+    const fetchMock = vi.fn();
+    const confirmMock = vi.fn();
+
+    const result = await detectAndApplySceneChange({
+      originalPrompt: 'No structured data here',
+      updatedPrompt: 'No structured data here',
+      oldValue: 'Forest',
+      newValue: 'Desert',
+      fetchImpl: fetchMock,
+      confirmSceneChange: confirmMock,
+    });
+
+    expect(result).toBe('No structured data here');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it('skips scene change updates when API reports no change', async () => {
+    const updatedPrompt = basePrompt.replace(
+      '- Environment Type: [Forest]',
+      '- Environment Type: [Desert]'
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          isSceneChange: false,
+          confidence: 'high',
+        }),
+    });
+    const confirmMock = vi.fn();
+
+    const result = await detectAndApplySceneChange({
+      originalPrompt: basePrompt,
+      updatedPrompt,
+      oldValue: 'Forest',
+      newValue: 'Desert',
+      fetchImpl: fetchMock,
+      confirmSceneChange: confirmMock,
+    });
+
+    expect(result).toBe(updatedPrompt);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(confirmMock).not.toHaveBeenCalled();
+
+    const [, fetchOptions] = fetchMock.mock.calls[0];
+    const body = JSON.parse(fetchOptions.body);
+    expect(body).toMatchObject({
+      changedField: 'Environment Type',
+      oldValue: 'Forest',
+      newValue: 'Desert',
+      affectedFields: {
+        'Architectural Details': 'Wooden cabins',
+        'Environmental Scale': 'Intimate',
+        'Atmospheric Conditions': 'Misty',
+        'Background Elements': 'Tall pines',
+        'Foreground Elements': 'Mossy rocks',
+        'Spatial Depth': 'Layered',
+        'Environmental Storytelling': 'Tranquil retreat',
+      },
+    });
+  });
+
+  it('applies suggested updates when scene change is confirmed', async () => {
+    const updatedPrompt = basePrompt.replace(
+      '- Environment Type: [Forest]',
+      '- Environment Type: [Desert Oasis]'
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          isSceneChange: true,
+          confidence: 'high',
+          reasoning: 'A radically different biome.',
+          suggestedUpdates: {
+            'Architectural Details': 'Adobe dwellings',
+            'Atmospheric Conditions': 'Dry heat',
+          },
+        }),
+    });
+    const confirmMock = vi.fn().mockReturnValue(true);
+
+    const result = await detectAndApplySceneChange({
+      originalPrompt: basePrompt,
+      updatedPrompt,
+      oldValue: 'Forest',
+      newValue: 'Desert Oasis',
+      fetchImpl: fetchMock,
+      confirmSceneChange: confirmMock,
+    });
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    const confirmationMessage = confirmMock.mock.calls[0][0];
+    expect(confirmationMessage).toContain('Desert Oasis');
+    expect(result).toContain('- Architectural Details: [Adobe dwellings]');
+    expect(result).toContain('- Atmospheric Conditions: [Dry heat]');
+    expect(result).toContain('- Environment Type: [Desert Oasis]');
+  });
+
+  it('does not update fields when confirmation is declined', async () => {
+    const updatedPrompt = basePrompt.replace(
+      '- Environment Type: [Forest]',
+      '- Environment Type: [Underwater City]'
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          isSceneChange: true,
+          confidence: 'medium',
+          reasoning: 'Submerged settings have different requirements.',
+          suggestedUpdates: {
+            'Architectural Details': 'Coral structures',
+          },
+        }),
+    });
+    const confirmMock = vi.fn().mockReturnValue(false);
+
+    const result = await detectAndApplySceneChange({
+      originalPrompt: basePrompt,
+      updatedPrompt,
+      oldValue: 'Forest',
+      newValue: 'Underwater City',
+      fetchImpl: fetchMock,
+      confirmSceneChange: confirmMock,
+    });
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(updatedPrompt);
+  });
+
+  it('returns baseline prompt when the API request fails', async () => {
+    const updatedPrompt = basePrompt.replace(
+      '- Environment Type: [Forest]',
+      '- Environment Type: [Ice Caves]'
+    );
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network error'));
+    const confirmMock = vi.fn();
+
+    const result = await detectAndApplySceneChange({
+      originalPrompt: basePrompt,
+      updatedPrompt,
+      oldValue: 'Forest',
+      newValue: 'Ice Caves',
+      fetchImpl: fetchMock,
+      confirmSceneChange: confirmMock,
+    });
+
+    expect(result).toBe(updatedPrompt);
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- persist the selection range and offsets with each enhancement suggestion request so the highlighted span can be reapplied precisely
- replace naive text replacement with offset-based slicing and run the shared detectAndApplySceneChange helper before committing edits
- add the reusable detectAndApplySceneChange utility and cover it with dedicated unit tests

## Testing
- npm run test:unit *(fails: existing apiAuthMiddleware expectation in server/src/middleware/__tests__/apiAuth.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68f7e89718c4832d948f8d5487269226