### PR TITLE
Add confidence metadata to highlight spans

### DIFF
--- a/client/src/features/prompt-optimizer/PromptCanvas.jsx
+++ b/client/src/features/prompt-optimizer/PromptCanvas.jsx
@@ -45,6 +45,13 @@ export const formatTextToHTML = (
       .replace(/'/g, '&#039;');
   };
 
+  const getConfidenceClass = (confidence) => {
+    if (typeof confidence !== 'number') return '';
+    if (confidence >= 0.85) return 'high-confidence';
+    if (confidence >= 0.7) return 'medium-confidence';
+    return 'low-confidence';
+  };
+
   /**
    * Intelligent phrase highlighting system using ML-based pattern recognition
    *
@@ -128,7 +135,12 @@ export const formatTextToHTML = (
       result += escapeHtml(input.slice(lastIndex, start));
 
       // Add highlighted phrase
-      result += `<span class="value-word value-word-${phrase.category}" data-category="${phrase.category}" style="background-color: ${phrase.color.bg}; border-bottom: 2px solid ${phrase.color.border}; padding: 1px 3px; border-radius: 3px; cursor: pointer;">${escapeHtml(phrase.text)}</span>`;
+      const confidenceClass = getConfidenceClass(phrase.confidence);
+      const className = `value-word value-word-${phrase.category}${confidenceClass ? ` ${confidenceClass}` : ''}`;
+      const confidenceAttr =
+        typeof phrase.confidence === 'number' ? ` data-confidence="${phrase.confidence}"` : '';
+
+      result += `<span class="${className}" data-category="${phrase.category}"${confidenceAttr} style="background-color: ${phrase.color.bg}; border-bottom: 2px solid ${phrase.color.border}; padding: 1px 3px; border-radius: 3px; cursor: pointer;">${escapeHtml(phrase.text)}</span>`;
 
       lastIndex = start + phrase.text.length;
     });

--- a/client/src/features/prompt-optimizer/__tests__/PromptCanvas.test.jsx
+++ b/client/src/features/prompt-optimizer/__tests__/PromptCanvas.test.jsx
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../phraseExtractor', () => ({
+  extractVideoPromptPhrases: vi.fn(),
+}));
+
+import { formatTextToHTML } from '../PromptCanvas.jsx';
+import { extractVideoPromptPhrases } from '../phraseExtractor';
+
+describe('formatTextToHTML', () => {
+  beforeEach(() => {
+    extractVideoPromptPhrases.mockReset();
+  });
+
+  it('includes confidence class names and data attribute on highlighted spans', () => {
+    extractVideoPromptPhrases.mockReturnValue([
+      {
+        text: 'highlight phrase',
+        category: 'test-category',
+        confidence: 0.75,
+        color: { bg: 'rgba(0,0,0,0.1)', border: 'rgba(0,0,0,0.2)' },
+      },
+    ]);
+
+    const { html } = formatTextToHTML('This is a highlight phrase example.', true);
+
+    expect(html).toContain('class="value-word value-word-test-category medium-confidence"');
+    expect(html).toContain('data-confidence="0.75"');
+  });
+});


### PR DESCRIPTION
## Summary
- map ML highlight confidence scores to semantic CSS class names in `formatTextToHTML`
- expose each span's numeric confidence via a `data-confidence` attribute for future UX hooks
- cover the new markup via a dedicated unit test for `formatTextToHTML`

## Testing
- npx vitest run client/src/features/prompt-optimizer/__tests__/PromptCanvas.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68f7f0a10a1c832d8f0dd311b2cd511f