### PR TITLE
Pass brainstorm context during re-optimization

### DIFF
--- a/client/src/features/prompt-optimizer/PromptOptimizerContainer.jsx
+++ b/client/src/features/prompt-optimizer/PromptOptimizerContainer.jsx
@@ -196,11 +196,33 @@ function PromptOptimizerContent() {
   const handleOptimize = async (promptToOptimize, context) => {
     const prompt = promptToOptimize || promptOptimizer.inputPrompt;
     const ctx = context || promptOptimizer.improvementContext;
-    console.log('handleOptimize called with:', { prompt, ctx, selectedMode });
-    const result = await promptOptimizer.optimize(prompt, ctx);
+
+    const serializedContext = promptContext
+      ? typeof promptContext.toJSON === 'function'
+        ? promptContext.toJSON()
+        : {
+            elements: promptContext.elements,
+            metadata: promptContext.metadata,
+          }
+      : null;
+
+    const brainstormContextData = serializedContext
+      ? {
+          elements: serializedContext.elements,
+          metadata: serializedContext.metadata,
+        }
+      : null;
+
+    console.log('handleOptimize called with:', {
+      prompt,
+      ctx,
+      selectedMode,
+      hasBrainstormContext: Boolean(brainstormContextData),
+    });
+
+    const result = await promptOptimizer.optimize(prompt, ctx, brainstormContextData);
     console.log('optimize result:', result);
     if (result) {
-      const serializedContext = promptContext ? promptContext.toJSON() : null;
       const uuid = await promptHistory.saveToHistory(
         prompt,
         result.optimized,


### PR DESCRIPTION
## Summary
- derive the serialized brainstorm context from `PromptContext` before re-running optimization
- pass a plain `{ elements, metadata }` payload to the optimizer API while continuing to persist the full serialized context with history entries

## Testing
- not run (UI manual verification required)


------
https://chatgpt.com/codex/tasks/task_e_68f7f0ab7728832d9c65afa7bc256c3e