### PR TITLE
Fix video prompt detection for targeted suggestions

### DIFF
--- a/server/src/services/EnhancementService.js
+++ b/server/src/services/EnhancementService.js
@@ -590,11 +590,42 @@ export class EnhancementService {
    * @private
    */
   isVideoPrompt(fullPrompt) {
-    return (
-      fullPrompt.includes('**Main Prompt:**') ||
-      fullPrompt.includes('**Technical Parameters:**') ||
-      fullPrompt.includes('Camera Movement:')
-    );
+    if (typeof fullPrompt !== 'string' || fullPrompt.trim().length === 0) {
+      return false;
+    }
+
+    const normalized = fullPrompt.toLowerCase();
+
+    const legacyMarkers = ['**main prompt:**', '**technical parameters:**', 'camera movement:'];
+    if (legacyMarkers.some((marker) => normalized.includes(marker))) {
+      return true;
+    }
+
+    const modernTemplateMarkers = [
+      '**prompt:**',
+      '**guiding principles',
+      '**writing rules',
+      '**technical specs',
+      '**alternative approaches',
+      'variation 1 (different camera)',
+      'variation 2 (different lighting/mood)',
+    ];
+
+    if (modernTemplateMarkers.some((marker) => normalized.includes(marker))) {
+      return true;
+    }
+
+    const technicalFields = ['duration:', 'aspect ratio:', 'frame rate:', 'audio:'];
+    const matchedTechFields = technicalFields.filter((field) => normalized.includes(field));
+    if (normalized.includes('technical specs') && matchedTechFields.length >= 2) {
+      return true;
+    }
+
+    if (matchedTechFields.length >= 3 && normalized.includes('alternative approaches')) {
+      return true;
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
## Summary
- expand `EnhancementService.isVideoPrompt` to recognize the new universal video template markers so single word selections stay scoped
- add regression coverage for the new detection logic and update the enhancement suggestion test fixture to the 2025 video template
- adjust server unit test bootstrapping to import the Express app directly and stub required environment variables

## Testing
- npm run test:unit *(partially executed; aborted after ~50s due to very large suite)*
- npx vitest run tests/unit/server/server.test.js --config config/test/vitest.config.js *(fails in pre-existing API error assertions while exercising new cases)*

------
https://chatgpt.com/codex/tasks/task_e_68f84ab93654832da1aa9ec74c6aaa94