### PR TITLE
Enforce authenticated video preview credits

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -14,5 +14,14 @@ service cloud.firestore {
       // Allow users to update/delete their own prompts
       allow update, delete: if request.auth != null && resource.data.userId == request.auth.uid;
     }
+
+    // User accounts and credit balances
+    match /users/{userId} {
+      // Users can read their own profile and credit balance
+      allow read: if request.auth != null && request.auth.uid == userId;
+
+      // Prevent client-side writes to credit balance; only backend via Admin SDK should update
+      allow write: if false;
+    }
   }
 }

--- a/server/src/config/modelCosts.ts
+++ b/server/src/config/modelCosts.ts
@@ -1,0 +1,18 @@
+import { VIDEO_MODELS } from './modelConfig';
+
+export const VIDEO_GENERATION_COSTS = {
+  [VIDEO_MODELS.SORA_2]: 50,
+  [VIDEO_MODELS.SORA_2_PRO]: 50,
+  [VIDEO_MODELS.LUMA_RAY3]: 25,
+  [VIDEO_MODELS.KLING_V2_1]: 25,
+  [VIDEO_MODELS.VEO_3]: 20,
+  [VIDEO_MODELS.TIER_1]: 10,
+  [VIDEO_MODELS.DRAFT]: 5,
+} as const;
+
+export const DEFAULT_VIDEO_COST = 25;
+
+export function getVideoCost(modelId?: string): number {
+  if (!modelId) return DEFAULT_VIDEO_COST;
+  return VIDEO_GENERATION_COSTS[modelId as keyof typeof VIDEO_GENERATION_COSTS] || DEFAULT_VIDEO_COST;
+}

--- a/server/src/config/routes.config.ts
+++ b/server/src/config/routes.config.ts
@@ -26,6 +26,7 @@ import { createRoleClassifyRoute } from '@routes/roleClassifyRoute';
 import { createLabelSpansRoute } from '@routes/labelSpansRoute';
 import { createSuggestionsRoute } from '@routes/suggestions';
 import { createPreviewRoutes } from '@routes/preview.routes';
+import { userCreditService } from '@services/credits/UserCreditService';
 
 /**
  * Register all application routes
@@ -93,6 +94,7 @@ export function registerRoutes(app: Application, container: DIContainer): void {
   const previewRoutes = createPreviewRoutes({
     imageGenerationService: container.resolve('imageGenerationService'),
     videoGenerationService: container.resolve('videoGenerationService'),
+    userCreditService,
   });
   app.use('/api/preview', apiAuthMiddleware, previewRoutes);
 
@@ -142,4 +144,3 @@ export function configureRoutes(app: Application, container: DIContainer): void 
   registerRoutes(app, container);
   registerErrorHandlers(app);
 }
-

--- a/server/src/infrastructure/firebaseAdmin.ts
+++ b/server/src/infrastructure/firebaseAdmin.ts
@@ -1,0 +1,46 @@
+import * as admin from 'firebase-admin';
+import { readFileSync } from 'fs';
+import { logger } from './Logger';
+
+let initialized = false;
+
+function initializeFirebaseAdmin(): admin.app.App {
+  if (initialized && admin.apps.length > 0) {
+    return admin.app();
+  }
+
+  try {
+    const serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT_PATH;
+
+    if (serviceAccountPath) {
+      const serviceAccount = JSON.parse(readFileSync(serviceAccountPath, 'utf8'));
+      admin.initializeApp({
+        credential: admin.credential.cert(serviceAccount),
+        projectId: process.env.VITE_FIREBASE_PROJECT_ID,
+      });
+    } else {
+      admin.initializeApp({
+        credential: admin.credential.applicationDefault(),
+        projectId: process.env.VITE_FIREBASE_PROJECT_ID,
+      });
+    }
+
+    initialized = true;
+    logger.info('Firebase Admin initialized', {
+      projectId: process.env.VITE_FIREBASE_PROJECT_ID,
+      hasServiceAccount: Boolean(serviceAccountPath),
+    });
+
+    return admin.app();
+  } catch (error) {
+    logger.error('Failed to initialize Firebase Admin SDK', error as Error);
+    throw error;
+  }
+}
+
+export function getFirestore(): FirebaseFirestore.Firestore {
+  const app = initializeFirebaseAdmin();
+  return admin.firestore(app);
+}
+
+export { admin };

--- a/server/src/routes/preview.routes.ts
+++ b/server/src/routes/preview.routes.ts
@@ -6,11 +6,14 @@
 
 import type { Router, Request, Response } from 'express';
 import express from 'express';
+import { isIP } from 'node:net';
 import { logger } from '@infrastructure/Logger';
-import { extractUserId } from '@utils/requestHelpers';
+import { admin } from '@infrastructure/firebaseAdmin';
 import { asyncHandler } from '@middleware/asyncHandler';
 import { parseVideoPreviewRequest, sendVideoContent } from '@routes/preview/videoRequest';
+import { getVideoCost } from '@config/modelCosts';
 import type { PreviewRoutesServices } from './types';
+import { userCreditService as defaultUserCreditService } from '@services/credits/UserCreditService';
 
 /**
  * Create preview routes
@@ -18,7 +21,40 @@ import type { PreviewRoutesServices } from './types';
 export function createPreviewRoutes(services: PreviewRoutesServices): Router {
   const router = express.Router();
 
-  const { imageGenerationService, videoGenerationService } = services;
+  const {
+    imageGenerationService,
+    videoGenerationService,
+    userCreditService = defaultUserCreditService,
+  } = services;
+
+  async function getAuthenticatedUserId(req: Request): Promise<string | null> {
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.startsWith('Bearer ')
+      ? authHeader.substring('Bearer '.length).trim()
+      : undefined;
+
+    if (!token) {
+      logger.warn('Missing authentication token for video generation', {
+        path: req.path,
+        ip: req.ip,
+      });
+      return null;
+    }
+
+    try {
+      const decoded = await admin.auth().verifyIdToken(token);
+      const uid = decoded.uid;
+      (req as Request & { user?: { uid?: string } }).user = { uid };
+      return uid;
+    } catch (error) {
+      logger.warn('Invalid authentication token for video generation', {
+        path: req.path,
+        ip: req.ip,
+        error: (error as Error)?.message,
+      });
+      return null;
+    }
+  }
 
   // POST /api/preview/generate - Generate image preview
   router.post(
@@ -50,12 +86,41 @@ export function createPreviewRoutes(services: PreviewRoutesServices): Router {
       }
 
       const { prompt, aspectRatio, model, startImage, inputReference } = parsed.payload;
-      const userId = extractUserId(req);
+      const userId = await getAuthenticatedUserId(req);
+
+      if (!userId || userId === 'anonymous' || isIP(userId) !== 0) {
+        return res.status(401).json({
+          success: false,
+          error: 'Authentication required',
+          message: 'You must be logged in to generate videos.',
+        });
+      }
+
+      if (!userCreditService) {
+        logger.error('User credit service is not available - blocking paid feature access', {
+          path: req.path,
+        });
+        return res.status(503).json({
+          success: false,
+          error: 'Video generation service is not available',
+          message: 'Credit service is not configured',
+        });
+      }
 
       const startTime = performance.now();
       const operation = 'generateVideoPreview';
       const requestId = (req as Request & { id?: string }).id;
-      
+      const estimatedCost = getVideoCost(model);
+
+      const hasCredits = await userCreditService.reserveCredits(userId, estimatedCost);
+      if (!hasCredits) {
+        return res.status(402).json({
+          success: false,
+          error: 'Insufficient credits',
+          message: `This generation requires ${estimatedCost} credits.`,
+        });
+      }
+
       logger.debug(`Starting ${operation}`, {
         operation,
         requestId,
@@ -63,6 +128,7 @@ export function createPreviewRoutes(services: PreviewRoutesServices): Router {
         promptLength: prompt.length,
         aspectRatio,
         model,
+        estimatedCost,
       });
 
       try {
@@ -78,21 +144,26 @@ export function createPreviewRoutes(services: PreviewRoutesServices): Router {
           requestId,
           userId,
           duration: Math.round(performance.now() - startTime),
+          cost: estimatedCost,
         });
 
         return res.json({
           success: true,
           videoUrl: result,
+          creditsDeducted: estimatedCost,
         });
       } catch (error) {
+        await userCreditService.refundCredits(userId, estimatedCost);
+
         const errorMessage = error instanceof Error ? error.message : String(error);
         const statusCode = (error as { statusCode?: number }).statusCode || 500;
-        
+
         logger.error(`${operation} failed`, error as Error, {
           operation,
           requestId,
           userId,
           duration: Math.round(performance.now() - startTime),
+          refundAmount: estimatedCost,
           statusCode,
         });
 

--- a/server/src/routes/types.ts
+++ b/server/src/routes/types.ts
@@ -6,6 +6,7 @@ import type { Router } from 'express';
 import type { ImageGenerationService } from '@services/image-generation/ImageGenerationService';
 import type { VideoGenerationService } from '@services/video-generation/VideoGenerationService';
 import type { AIModelService } from '@services/ai-model/AIModelService';
+import type { UserCreditService } from '@services/credits/UserCreditService';
 
 /**
  * Services object for preview routes
@@ -13,10 +14,10 @@ import type { AIModelService } from '@services/ai-model/AIModelService';
 export interface PreviewRoutesServices {
   imageGenerationService: ImageGenerationService | null;
   videoGenerationService: VideoGenerationService | null;
+  userCreditService?: UserCreditService | null;
 }
 
 /**
  * Route factory return type
  */
 export type RouteFactory = () => Router;
-

--- a/server/src/services/credits/UserCreditService.ts
+++ b/server/src/services/credits/UserCreditService.ts
@@ -1,0 +1,67 @@
+import { admin, getFirestore } from '@infrastructure/firebaseAdmin';
+import { logger } from '@infrastructure/Logger';
+
+export class UserCreditService {
+  private db = getFirestore();
+  private collection = this.db.collection('users');
+
+  /**
+   * Checks if a user has enough credits and reserves them in a transaction.
+   * Deducts immediately to prevent double-spending during long-running generations.
+   */
+  async reserveCredits(userId: string, cost: number): Promise<boolean> {
+    const userRef = this.collection.doc(userId);
+
+    try {
+      return await this.db.runTransaction(async (transaction) => {
+        const snapshot = await transaction.get(userRef);
+
+        if (!snapshot.exists) {
+          transaction.set(userRef, {
+            credits: 100,
+            createdAt: admin.firestore.FieldValue.serverTimestamp(),
+          });
+          return true;
+        }
+
+        const data = snapshot.data();
+        const currentCredits = data?.credits ?? 0;
+
+        if (currentCredits < cost) {
+          return false;
+        }
+
+        transaction.update(userRef, {
+          credits: admin.firestore.FieldValue.increment(-cost),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+
+        return true;
+      });
+    } catch (error) {
+      logger.error('Credit reservation failed', error as Error, { userId, cost });
+      throw new Error('Failed to process credit transaction');
+    }
+  }
+
+  /**
+   * Refund credits when a generation fails.
+   */
+  async refundCredits(userId: string, cost: number): Promise<void> {
+    try {
+      await this.collection.doc(userId).update({
+        credits: admin.firestore.FieldValue.increment(cost),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+    } catch (error) {
+      logger.error('Credit refund failed', error as Error, { userId, cost });
+    }
+  }
+
+  async getBalance(userId: string): Promise<number> {
+    const snapshot = await this.collection.doc(userId).get();
+    return snapshot.data()?.credits ?? 0;
+  }
+}
+
+export const userCreditService = new UserCreditService();


### PR DESCRIPTION
## Summary
- add centralized video cost configuration and Firestore-backed user credit service
- require Firebase-authenticated users for video preview generation and reserve/refund credits around generation
- lock down Firestore rules to prevent client-side credit modification while allowing balance reads

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b43dee114832d959a71b8e32bc658)