### PR TITLE
Add arch:check to the commit protocol

### DIFF
--- a/.claude/skills/eval-gated-loop/SKILL.md
+++ b/.claude/skills/eval-gated-loop/SKILL.md
@@ -17,8 +17,8 @@ verification gate — this skill defines that gate and the cost tiers around it.
 ### The oracle: `npm run verify`
 
 `verify` **is** the mandatory Commit Protocol collapsed into one command:
-`tsc --noEmit` → `eslint --quiet` → `test:unit`. Offline, deterministic, no API keys,
-no network. Run it after every change. Non-zero exit means the iteration **failed** —
+`tsc --noEmit` → `eslint --quiet` → `arch:check` → `test:unit` → `test:replay`.
+Offline, deterministic, no API keys, no network. Run it after every change. Non-zero exit means the iteration **failed** —
 do not commit; fix and re-run. If you believe something is "done" but `verify` is red,
 it is not done.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,15 +213,23 @@ npm run migrate:backfill
 
 ## Commit Protocol (MANDATORY)
 
-Before EVERY commit, run all three checks in order:
+Before EVERY commit, run all five checks in order:
 
 1. `npx tsc --noEmit` — must exit 0
 2. `npx eslint --config config/lint/eslint.config.js . --quiet` — must have 0 errors
-3. `npm run test:unit` — must pass all shards
+3. `npm run arch:check` — no circular imports, no forbidden cross-layer imports (~12s)
+4. `npm run test:unit` — must pass all shards
+5. `npm run test:replay` — golden-path replay suite (offline, ~5s) must pass
+
+`npm run verify` runs all five in that order.
+
+Check 3 is here because `tsc` accepts a type-only import cycle and the other
+four gates cannot see one: two cycles reached `main` on 2026-08-08 with every
+other gate green.
 
 If any check fails, DO NOT commit. Fix the failures first.
 
-A pre-commit hook enforces checks 1-2 automatically, plus: **fix commits must include a regression test** (the hook rejects `fix:` / `fix(` commits without new test blocks). Run `bash scripts/install-hooks.sh` to install it.
+A pre-commit hook enforces checks 1-3 automatically, plus: **fix commits must include a regression test** (the hook rejects `fix:` / `fix(` commits without new test blocks). Run `bash scripts/install-hooks.sh` to install it.
 
 ### Integration Test Gate (Service Changes)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,16 +267,24 @@ Worktrees may not have valid Firebase credentials. The startup probe (`admin.aut
 
 ## Commit Protocol (MANDATORY)
 
-Before EVERY commit, run all four checks in order:
+Before EVERY commit, run all five checks in order:
 
 1. `npx tsc --noEmit` — must exit 0
 2. `npx eslint --config config/lint/eslint.config.js . --quiet` — must have 0 errors
-3. `npm run test:unit` — must pass all shards
-4. `npm run test:replay` — golden-path replay suite (offline, ~5s) must pass
+3. `npm run arch:check` — no circular imports, no forbidden cross-layer imports (~12s)
+4. `npm run test:unit` — must pass all shards
+5. `npm run test:replay` — golden-path replay suite (offline, ~5s) must pass
+
+`npm run verify` runs all five in that order.
+
+Check 3 is here because `tsc` accepts a type-only import cycle and the other
+four gates cannot see one: two cycles reached `main` on 2026-08-08 with every
+other gate green. It also catches a client→server import, which no type error
+would report.
 
 If any check fails, DO NOT commit. Fix the failures first.
 
-A pre-commit hook enforces checks 1-2 automatically. The commit-msg hook enforces the bugfix protocol: **fix commits must add a regression test in a `*.regression.test.*` file**, and any commit touching regression tests must pass the mock-boundary quality check (`scripts/check-regression-test-quality.sh`). When no correct test seam exists, declare `No-Seam: <reason>` in the commit body — the missing seam is an architecture finding, not a free pass. Run `bash scripts/install-hooks.sh` after cloning.
+A pre-commit hook enforces checks 1-3 automatically. The commit-msg hook enforces the bugfix protocol: **fix commits must add a regression test in a `*.regression.test.*` file**, and any commit touching regression tests must pass the mock-boundary quality check (`scripts/check-regression-test-quality.sh`). When no correct test seam exists, declare `No-Seam: <reason>` in the commit body — the missing seam is an architecture finding, not a free pass. Run `bash scripts/install-hooks.sh` after cloning.
 
 ### Test Policy
 

--- a/client/GEMINI.md
+++ b/client/GEMINI.md
@@ -99,15 +99,21 @@ API placement rules:
 
 ## Commit Protocol (MANDATORY)
 
-Before EVERY commit, run all three checks in order:
+Before EVERY commit, run all five checks in order:
 
 1. `npx tsc --noEmit` — must exit 0
 2. `npx eslint --config config/lint/eslint.config.js . --quiet` — must have 0 errors
-3. `npm run test:unit` — must pass all shards
+3. `npm run arch:check` — no circular imports, no forbidden cross-layer imports (~12s)
+4. `npm run test:unit` — must pass all shards
+5. `npm run test:replay` — golden-path replay suite (offline, ~5s) must pass
+
+`npm run verify` runs all five in that order. Check 3 is the only local gate
+that sees a type-only import cycle (`tsc` accepts them) or a client→server
+import.
 
 If any check fails, DO NOT commit. Fix the failures first.
 
-A pre-commit hook enforces checks 1-2 automatically. Run `bash scripts/install-hooks.sh` after cloning.
+A pre-commit hook enforces checks 1-3 automatically. Run `bash scripts/install-hooks.sh` after cloning.
 
 ### Commit Scope Rules
 

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "test:regression:list": "bash scripts/audit-regression-tests.sh",
     "test:regression:quality": "bash scripts/check-regression-test-quality.sh",
     "test:all": "npm run test:unit && npm run test:e2e",
-    "verify": "npx tsc --noEmit && npx eslint --config config/lint/eslint.config.js . --quiet && npm run test:unit && npm run test:replay",
+    "verify": "npx tsc --noEmit && npx eslint --config config/lint/eslint.config.js . --quiet && npm run arch:check && npm run test:unit && npm run test:replay",
     "verify:drift": "npm run routemap:check && npm run flagdocs:check && npm run architecture:map:check && npm run catalogs:check",
     "verify:eval": "npm run eval:golden-set",
     "verify:all": "npm run verify && npm run verify:drift",

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -15,6 +15,13 @@ npx tsc --noEmit
 echo ">> Pre-commit: lint (errors only)"
 npx eslint --config config/lint/eslint.config.js . --quiet
 
+# Circular imports and forbidden cross-layer imports. ~12s.
+# tsc accepts a type-only import cycle, so this is the only local check that
+# sees one: two cycles reached main because the four gates above were all
+# green (2026-08-08, the provider-port work).
+echo ">> Pre-commit: architecture (cycles + forbidden imports)"
+npm run arch:check
+
 # Keep the local Obsidian vault (docs/ opened as a vault) in sync with the
 # architecture map. Non-blocking: a docs visualization must never stop a
 # commit, and older branches don't have the generator.

--- a/server/src/services/video-generation/types.ts
+++ b/server/src/services/video-generation/types.ts
@@ -33,8 +33,6 @@ export interface VideoGenerationServiceOptions {
   assetStore?: VideoAssetStore;
 }
 
-
-
 export interface VideoGenerationResult {
   assetId: string;
   videoUrl: string;


### PR DESCRIPTION
## Why

Two circular imports reached `main` on 2026-08-08 with all four commit gates green. `tsc` accepts a type-only import cycle, so no local check could see them — CI's `arch-check` caught them on the first PR of the stack.

A gate that only runs after push is not part of the protocol, and the protocol is what agents and humans actually follow.

## What changed

`arch:check` becomes **check 3**, between lint and the test suites:

1. `tsc --noEmit`
2. `eslint --quiet`
3. **`arch:check`** ← new (~12s)
4. `test:unit`
5. `test:replay`

Position matters: it costs 12s, so running it before the slow suites makes a structural fault fail fast. It is the only local gate that sees a type-only cycle or a `client → server` import — neither produces a type error.

The **pre-commit hook** enforces checks 1–3 now, so this does not depend on remembering to run it. Reinstall with `bash scripts/install-hooks.sh`.

## Verification

I reintroduced the exact cycle that shipped and ran both gates against it:

| gate | result |
|---|---|
| `tsc --noEmit` | **0 errors** |
| `arch:check` | **exit 1** — `interfaces/IAIClient.ts > interfaces/ILLMAdapter.ts` |

`npm run verify` (all five) passes: 6,952 unit tests, replay 7/7, exit 0.

## Drift found along the way

The protocol was stated in four places and three had already drifted:

- `AGENTS.md` — listed three checks, omitted `test:replay`
- `client/GEMINI.md` — same
- `.claude/skills/eval-gated-loop/SKILL.md` — enumerated the same stale three, while claiming to be "byte-for-byte identical to the Commit Protocol"

All four now agree and each points at `npm run verify` as the single command, so the next change to the protocol has one place to edit and three places that defer to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Added architecture validation to the standard verification workflow.
  * Verification now checks TypeScript, linting, architecture, unit tests, and replay tests in sequence.
  * Pre-commit checks now block changes that introduce circular or forbidden cross-layer imports.
* **Documentation**
  * Updated development guidance to describe the expanded verification and commit requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->